### PR TITLE
Use io.quarkus BOM rather than io.quarkus.platform

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>io.quarkus.platform</groupId>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-bom</artifactId>
                 <version>${quarkus.version}</version>
                 <type>pom</type>


### PR DESCRIPTION
The latter is not available in Ecosystem CI as it's part of the platform
and we don't build the platform.