### PR TITLE
Add PathParam/QueryParam support.

### DIFF
--- a/deployment/src/test/java/io/quarkus/reactivemessaging/http/source/app/Consumer.java
+++ b/deployment/src/test/java/io/quarkus/reactivemessaging/http/source/app/Consumer.java
@@ -49,6 +49,18 @@ public class Consumer {
         return result;
     }
 
+    @Incoming("post-http-source-with-pathparam")
+    public CompletionStage<Void> process2(Message<?> message) {
+        CompletableFuture<Void> result = new CompletableFuture<>();
+
+        lock.triggerWhenUnlocked(() -> {
+            postMessages.add(message);
+            message.ack();
+            result.complete(null);
+        }, 10000);
+        return result;
+    }
+
     @Incoming("put-http-source")
     @Acknowledgment(Acknowledgment.Strategy.POST_PROCESSING)
     public CompletionStage<Void> processPut(Message<?> message) {

--- a/deployment/src/test/java/io/quarkus/reactivemessaging/websocket/WebSocketClient.java
+++ b/deployment/src/test/java/io/quarkus/reactivemessaging/websocket/WebSocketClient.java
@@ -25,13 +25,14 @@ public class WebSocketClient {
 
     public WsConnection connect(URI uri, long timeout, TimeUnit unit) {
         CompletableFuture<WebSocket> webSocket = new CompletableFuture<>();
-        vertx.createHttpClient().webSocket(uri.getPort(), uri.getHost(), uri.getPath(), ws -> {
-            if (ws.succeeded()) {
-                webSocket.complete(ws.result());
-            } else {
-                webSocket.completeExceptionally(ws.cause());
-            }
-        });
+        vertx.createHttpClient().webSocket(uri.getPort(), uri.getHost(),
+                uri.getPath() + (uri.getQuery() != null ? "?" + uri.getQuery() : ""), ws -> {
+                    if (ws.succeeded()) {
+                        webSocket.complete(ws.result());
+                    } else {
+                        webSocket.completeExceptionally(ws.cause());
+                    }
+                });
         try {
             return new WsConnection(webSocket.get(timeout, unit));
         } catch (InterruptedException | ExecutionException | TimeoutException e) {

--- a/deployment/src/test/resources/http-source-test-application.properties
+++ b/deployment/src/test/resources/http-source-test-application.properties
@@ -19,3 +19,7 @@ mp.messaging.incoming.string-http-source.connector=quarkus-http
 mp.messaging.incoming.string-http-source.path=/string-http-source
 mp.messaging.incoming.string-http-source.method=POST
 
+mp.messaging.incoming.post-http-source-with-pathparam.connector=quarkus-http
+mp.messaging.incoming.post-http-source-with-pathparam.path=/shoes/:shoetype
+mp.messaging.incoming.post-http-source-with-pathparam.method=POST
+

--- a/deployment/src/test/resources/websocket-source-test-application.properties
+++ b/deployment/src/test/resources/websocket-source-test-application.properties
@@ -7,3 +7,6 @@ mp.messaging.incoming.my-ws-source-json.path=/my-ws-json
 mp.messaging.incoming.my-ws-source-buffer-13.connector=quarkus-websocket
 mp.messaging.incoming.my-ws-source-buffer-13.path=/my-ws-buffer-13
 mp.messaging.incoming.my-ws-source-buffer-13.buffer-size=13
+
+mp.messaging.incoming.my-ws-pathparam.connector=quarkus-websocket
+mp.messaging.incoming.my-ws-pathparam.path=/shoes/:shoetype

--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,4 +1,4 @@
-:quarkus-version: 2.7.3.Final
+:quarkus-version: 2.10.2.Final
 :project-version: 1.0.3
 :maven-version: 3.8.1+
 

--- a/runtime/src/main/java/io/quarkus/reactivemessaging/http/runtime/IncomingHttpMetadata.java
+++ b/runtime/src/main/java/io/quarkus/reactivemessaging/http/runtime/IncomingHttpMetadata.java
@@ -3,16 +3,18 @@ package io.quarkus.reactivemessaging.http.runtime;
 import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
+import io.vertx.ext.web.RoutingContext;
 
 /**
  * Metadata for Http Source. Provides a way to get headers, method and path from a http request
  */
-public class IncomingHttpMetadata {
+public class IncomingHttpMetadata extends RequestMetadata {
 
     private final HttpServerRequest request;
 
-    IncomingHttpMetadata(HttpServerRequest request) {
-        this.request = request;
+    IncomingHttpMetadata(RoutingContext rc) {
+        super(rc);
+        this.request = rc.request();
     }
 
     /**

--- a/runtime/src/main/java/io/quarkus/reactivemessaging/http/runtime/PathMetadata.java
+++ b/runtime/src/main/java/io/quarkus/reactivemessaging/http/runtime/PathMetadata.java
@@ -1,0 +1,22 @@
+package io.quarkus.reactivemessaging.http.runtime;
+
+/**
+ * Metadata for a request path.
+ * 
+ * Invoked/Configured path may be different when using PathParameters.
+ */
+public interface PathMetadata {
+    /**
+     * Get the path used to invoke this request, eg /users/fred if the path was configured as /users/:userid
+     * 
+     * @return
+     */
+    public String getInvokedPath();
+
+    /**
+     * Get the path configured for this request, eg /users/:userid for a req using PathParams
+     * 
+     * @return
+     */
+    public String getConfiguredPath();
+}

--- a/runtime/src/main/java/io/quarkus/reactivemessaging/http/runtime/ReactiveHttpHandlerBean.java
+++ b/runtime/src/main/java/io/quarkus/reactivemessaging/http/runtime/ReactiveHttpHandlerBean.java
@@ -42,7 +42,7 @@ public class ReactiveHttpHandlerBean extends ReactiveHandlerBeanBase<HttpStreamC
 
     @Override
     protected String key(RoutingContext context) {
-        return key(context.normalizedPath(), context.request().method());
+        return key(context.currentRoute().getPath(), context.request().method());
     }
 
     @Override
@@ -58,7 +58,7 @@ public class ReactiveHttpHandlerBean extends ReactiveHandlerBeanBase<HttpStreamC
                     "No consumer subscribed for messages sent to Reactive Messaging HTTP endpoint on path: " + path);
         } else if (guard.prepareToEmit()) {
             try {
-                HttpMessage<Buffer> message = new HttpMessage<>(event.getBody(), new IncomingHttpMetadata(event.request()),
+                HttpMessage<Buffer> message = new HttpMessage<>(event.getBody(), new IncomingHttpMetadata(event),
                         () -> {
                             if (!event.response().ended()) {
                                 event.response().setStatusCode(202).end();

--- a/runtime/src/main/java/io/quarkus/reactivemessaging/http/runtime/ReactiveWebSocketHandlerBean.java
+++ b/runtime/src/main/java/io/quarkus/reactivemessaging/http/runtime/ReactiveWebSocketHandlerBean.java
@@ -44,6 +44,7 @@ public class ReactiveWebSocketHandlerBean extends ReactiveHandlerBeanBase<WebSoc
                                     } else if (guard.prepareToEmit()) {
                                         try {
                                             emitter.emit(new WebSocketMessage<>(b,
+                                                    new RequestMetadata(event),
                                                     () -> serverWebSocket.write(Buffer.buffer("ACK")),
                                                     error -> onUnexpectedError(serverWebSocket, error,
                                                             "Failed to process incoming web socket message.")));
@@ -71,7 +72,7 @@ public class ReactiveWebSocketHandlerBean extends ReactiveHandlerBeanBase<WebSoc
 
     @Override
     protected String key(RoutingContext context) {
-        return context.normalizedPath();
+        return context.currentRoute().getPath();
     }
 
     @Override

--- a/runtime/src/main/java/io/quarkus/reactivemessaging/http/runtime/RequestMetadata.java
+++ b/runtime/src/main/java/io/quarkus/reactivemessaging/http/runtime/RequestMetadata.java
@@ -1,0 +1,37 @@
+package io.quarkus.reactivemessaging.http.runtime;
+
+import java.util.Map;
+
+import io.vertx.core.MultiMap;
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * Common metadata class for incoming http/websockets.
+ */
+public class RequestMetadata implements PathMetadata {
+
+    private final RoutingContext event;
+
+    RequestMetadata(RoutingContext event) {
+        this.event = event;
+    }
+
+    public MultiMap getQueryParams() {
+        return event.queryParams();
+    }
+
+    public Map<String, String> getPathParams() {
+        return event.pathParams();
+    }
+
+    @Override
+    public String getInvokedPath() {
+        return event.normalizedPath();
+    }
+
+    @Override
+    public String getConfiguredPath() {
+        return event.currentRoute().getPath();
+    }
+
+}

--- a/runtime/src/main/java/io/quarkus/reactivemessaging/http/runtime/WebSocketMessage.java
+++ b/runtime/src/main/java/io/quarkus/reactivemessaging/http/runtime/WebSocketMessage.java
@@ -7,22 +7,31 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.Metadata;
 
 class WebSocketMessage<PayloadType> implements Message<PayloadType> {
 
     private final PayloadType payload;
     private final Runnable successHandler;
     private final Consumer<Throwable> failureHandler;
+    private final Metadata metadata;
 
-    WebSocketMessage(PayloadType payload, Runnable successHandler, Consumer<Throwable> failureHandler) {
+    WebSocketMessage(PayloadType payload, RequestMetadata requestMetadata, Runnable successHandler,
+            Consumer<Throwable> failureHandler) {
         this.payload = payload;
         this.successHandler = successHandler;
         this.failureHandler = failureHandler;
+        metadata = Metadata.of(requestMetadata);
     }
 
     @Override
     public PayloadType getPayload() {
         return payload;
+    }
+
+    @Override
+    public Metadata getMetadata() {
+        return metadata;
     }
 
     @Override


### PR DESCRIPTION
This change updates the HTTP and Websocket handling beans to match requests using the configured path, rather than the invoked path. This allows requests to match when paths are defined with path parameters, such as `/user/:userid` 

A new common metadata object is introduced that allows access to the pathParams and queryParams for the request, and also provides access to the invoked/configured path. This object becomes the parent of the existing incoming http metadata class. The new metadata object is added to WebSocket messages, allowing them to access pathParam/queryParam metadata.

