### PR TITLE
Add binary mode cloud event support

### DIFF
--- a/docs/modules/ROOT/pages/reactive-messaging-http.adoc
+++ b/docs/modules/ROOT/pages/reactive-messaging-http.adoc
@@ -348,6 +348,13 @@ mp.messaging.incoming.<channelName>.buffer-size=13
 
 ----
 
+=== Cloud Event support
+
+The HTTP connector supports binary-mode [cloud event] messages through Metadata.
+
+If incoming HTTP request contains headers of the form `ce-` or `ce_`, a `CloudEventMetadata` instance is included in the `Message` metadata
+
+If outgoing `Message` metadata includes a `CloudEventMetadata` instance, the information contained there will be added as headers prefixed with `ce-` in the outgoing HTTP request. 
 
 === Reactive Messaging
 This extension utilizes SmallRye Reactive Messaging to build data streaming applications.

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -10,6 +10,9 @@
     <name>Quarkus - SmallRye Reactive Messaging - HTTP and WebSockets - Integration Tests</name>
     <description>Integration tests for the Reactive Messaging HTTP and WebSockets extension</description>
 
+    <properties>
+      <version.com.github.tomakehurst.wiremock>2.33.0</version.com.github.tomakehurst.wiremock>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -52,6 +55,12 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock-jre8</artifactId>
+            <version>${version.com.github.tomakehurst.wiremock}</version>
+            <scope>test</scope>
+         </dependency>
     </dependencies>
 
     <build>

--- a/integration-tests/src/main/java/io/quarkus/reactivemessaging/http/CEListener.java
+++ b/integration-tests/src/main/java/io/quarkus/reactivemessaging/http/CEListener.java
@@ -1,0 +1,49 @@
+package io.quarkus.reactivemessaging.http;
+
+import java.util.concurrent.CompletionStage;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.Emitter;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.Metadata;
+
+import io.smallrye.reactive.messaging.ce.CloudEventMetadata;
+import io.smallrye.reactive.messaging.ce.OutgoingCloudEventMetadata;
+import io.smallrye.reactive.messaging.ce.OutgoingCloudEventMetadataBuilder;
+
+@ApplicationScoped
+public class CEListener {
+
+    @Inject
+    @Channel("ceresource")
+    Emitter<String> emitter;
+
+    @Incoming("celistener")
+    CompletionStage<Void> listener(Message<?> message) {
+        message.getMetadata(CloudEventMetadata.class).map(m -> Message.of("aBody", Metadata.of(convert(m))))
+                .ifPresent(this::send);
+        return message.ack();
+    }
+
+    private void send(Message<String> m) {
+        emitter.send(m);
+    }
+
+    private OutgoingCloudEventMetadata<?> convert(CloudEventMetadata<?> m) {
+        OutgoingCloudEventMetadataBuilder<?> builder = new OutgoingCloudEventMetadataBuilder<>();
+        m.getDataSchema().ifPresent(builder::withDataSchema);
+        m.getDataContentType().ifPresent(builder::withDataContentType);
+        m.getSubject().ifPresent(builder::withSubject);
+        m.getTimeStamp().ifPresent(builder::withTimestamp);
+        builder.withId(m.getId());
+        builder.withSource(m.getSource());
+        builder.withType(m.getType());
+        builder.withSpecVersion(m.getSpecVersion());
+        builder.withExtensions(m.getExtensions());
+        return builder.build();
+    }
+}

--- a/integration-tests/src/main/resources/application.properties
+++ b/integration-tests/src/main/resources/application.properties
@@ -13,3 +13,9 @@ mp.messaging.outgoing.http-sink.connector=quarkus-http
 mp.messaging.outgoing.http-sink.method=PUT
 mp.messaging.outgoing.http-sink.url=http://localhost:${quarkus.http.test-port:8081}/my-http-resource
 mp.messaging.outgoing.http-sink.serializer=io.quarkus.reactivemessaging.http.ToUpperCaseSerializer
+
+mp.messaging.incoming.celistener.connector=quarkus-http
+mp.messaging.incoming.celistener.path=/celistener
+
+mp.messaging.outgoing.ceresource.connector=quarkus-http
+mp.messaging.outgoing.ceresource.url=http://localhost:8282

--- a/integration-tests/src/test/java/io/quarkus/reactivemessaging/http/CEResourceMockService.java
+++ b/integration-tests/src/test/java/io/quarkus/reactivemessaging/http/CEResourceMockService.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.quarkus.reactivemessaging.http;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+
+import java.util.Collections;
+import java.util.Map;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import io.smallrye.reactive.messaging.ce.CloudEventMetadata;
+
+public class CEResourceMockService implements QuarkusTestResourceLifecycleManager {
+
+    private WireMockServer cloudEventService;
+
+    @Override
+    public Map<String, String> start() {
+        cloudEventService = new WireMockServer(8282);
+        cloudEventService.start();
+        cloudEventService.stubFor(post(urlEqualTo("/"))
+                .withHeader("ce-" + CloudEventMetadata.CE_ATTRIBUTE_TYPE, WireMock.equalTo("aType"))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("aBody")));
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public void stop() {
+        cloudEventService.stop();
+    }
+
+    @Override
+    public void inject(Object testInstance) {
+        ((ReactiveMessagingHttpTest) testInstance).cloudEventService = cloudEventService;
+    }
+}

--- a/integration-tests/src/test/java/io/quarkus/reactivemessaging/http/ReactiveMessagingHttpTest.java
+++ b/integration-tests/src/test/java/io/quarkus/reactivemessaging/http/ReactiveMessagingHttpTest.java
@@ -1,20 +1,47 @@
 package io.quarkus.reactivemessaging.http;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static io.restassured.RestAssured.delete;
 import static io.restassured.RestAssured.get;
 import static io.restassured.RestAssured.given;
 import static org.awaitility.Awaitility.await;
 
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.VerificationException;
+import com.github.tomakehurst.wiremock.client.WireMock;
+
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
+import io.smallrye.reactive.messaging.ce.CloudEventMetadata;
 
 @QuarkusTest
+@QuarkusTestResource(CEResourceMockService.class)
 public class ReactiveMessagingHttpTest {
+
+    WireMockServer cloudEventService;
+
+    @Test
+    void testCloudEvent() {
+        given().body("aBody").header("ce-type", "aType").post("/celistener");
+        await()
+                .atMost(2, TimeUnit.SECONDS).pollInterval(Duration.ofMillis(250)).until(() -> {
+                    try {
+                        cloudEventService.verify(postRequestedFor(urlEqualTo("/"))
+                                .withHeader("ce-" + CloudEventMetadata.CE_ATTRIBUTE_TYPE, WireMock.equalTo("aType")));
+                        return true;
+                    } catch (VerificationException ex) {
+                        return false;
+                    }
+                });
+    }
 
     @Test
     public void shouldSendAndConsumeWebSocketAndUseCustomSerializer() {

--- a/runtime/src/main/java/io/quarkus/reactivemessaging/http/runtime/HttpCloudEventHelper.java
+++ b/runtime/src/main/java/io/quarkus/reactivemessaging/http/runtime/HttpCloudEventHelper.java
@@ -1,0 +1,106 @@
+package io.quarkus.reactivemessaging.http.runtime;
+
+import java.net.URI;
+import java.time.DateTimeException;
+import java.time.ZonedDateTime;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.smallrye.reactive.messaging.ce.CloudEventMetadata;
+import io.smallrye.reactive.messaging.ce.DefaultCloudEventMetadataBuilder;
+import io.smallrye.reactive.messaging.ce.OutgoingCloudEventMetadata;
+
+public class HttpCloudEventHelper {
+
+    private static final Logger logger = LoggerFactory.getLogger(HttpCloudEventHelper.class);
+
+    private static final String[] CE_PREFIXES = { "ce-", "ce_" };
+
+    public static Optional<CloudEventMetadata<?>> getBinaryCloudEvent(IncomingHttpMetadata metadata) {
+        DefaultCloudEventMetadataBuilder<?> builder = new DefaultCloudEventMetadataBuilder<>();
+        boolean hasCloudMeta = false;
+        for (Entry<String, String> entry : metadata.getHeaders().entries()) {
+            hasCloudMeta |= getCEAttribute(builder, entry.getKey(), entry.getValue());
+        }
+        return hasCloudMeta ? Optional.of(builder.build()) : Optional.empty();
+    }
+
+    public static Map<String, String> getCloudEventHeaders(Message<?> message) {
+        return message.getMetadata(OutgoingCloudEventMetadata.class).map(HttpCloudEventHelper::getCloudEventHeaders)
+                .orElse(Collections.emptyMap());
+    }
+
+    private static Map<String, String> getCloudEventHeaders(OutgoingCloudEventMetadata<?> metadata) {
+        Map<String, String> map = new HashMap<>();
+        metadata.getDataContentType().ifPresent(v -> map.put(header(CloudEventMetadata.CE_ATTRIBUTE_DATA_CONTENT_TYPE), v));
+        metadata.getDataSchema().ifPresent(v -> map.put(header(CloudEventMetadata.CE_ATTRIBUTE_DATA_SCHEMA), v.toString()));
+        metadata.getSubject().ifPresent(v -> map.put(header(CloudEventMetadata.CE_ATTRIBUTE_SUBJECT), v));
+        metadata.getTimeStamp().ifPresent(v -> map.put(header(CloudEventMetadata.CE_ATTRIBUTE_TIME), v.toString()));
+        map.put(header(CloudEventMetadata.CE_ATTRIBUTE_ID), metadata.getId());
+        if (metadata.getSource() != null) {
+            map.put(header(CloudEventMetadata.CE_ATTRIBUTE_SOURCE), metadata.getSource().toString());
+        }
+        map.put(header(CloudEventMetadata.CE_ATTRIBUTE_SPEC_VERSION), metadata.getSpecVersion());
+        map.put(header(CloudEventMetadata.CE_ATTRIBUTE_TYPE), metadata.getType());
+        metadata.getExtensions().forEach((k, v) -> map.put(k, v.toString()));
+        return map;
+    }
+
+    private static String header(String key) {
+        return CE_PREFIXES[0] + key;
+    }
+
+    private static boolean getCEAttribute(DefaultCloudEventMetadataBuilder<?> builder, String key, String value) {
+        final String lowerCase = key.toLowerCase();
+        boolean sucessfulSet = false;
+        for (String prefix : CE_PREFIXES) {
+            if (lowerCase.startsWith(prefix)) {
+                try {
+                    switch (lowerCase.substring(prefix.length())) {
+                        case CloudEventMetadata.CE_ATTRIBUTE_ID:
+                            builder.withId(value);
+                            break;
+                        case CloudEventMetadata.CE_ATTRIBUTE_SOURCE:
+                            builder.withSource(URI.create(value));
+                            break;
+                        case CloudEventMetadata.CE_ATTRIBUTE_SPEC_VERSION:
+                            builder.withSpecVersion(value);
+                            break;
+                        case CloudEventMetadata.CE_ATTRIBUTE_SUBJECT:
+                            builder.withSubject(value);
+                            break;
+                        case CloudEventMetadata.CE_ATTRIBUTE_TIME:
+                            builder.withTimestamp(ZonedDateTime.parse(value));
+                            break;
+                        case CloudEventMetadata.CE_ATTRIBUTE_TYPE:
+                            builder.withType(value);
+                            break;
+                        case CloudEventMetadata.CE_ATTRIBUTE_DATA_CONTENT_TYPE:
+                            builder.withDataContentType(value);
+                            break;
+                        case CloudEventMetadata.CE_ATTRIBUTE_DATA_SCHEMA:
+                            builder.withDataSchema(URI.create(value));
+                            break;
+                        default:
+                            logger.info("Unrecognized CE attribute {}, assuming extension", key);
+                            builder.withExtension(key, value);
+                    }
+                    sucessfulSet = true;
+                } catch (IllegalArgumentException | DateTimeException ex) {
+                    logger.error("Error setting value {} for attribute {}", key, value, ex);
+                }
+            }
+        }
+        return sucessfulSet;
+    }
+
+    private HttpCloudEventHelper() {
+    }
+}

--- a/runtime/src/main/java/io/quarkus/reactivemessaging/http/runtime/HttpMessage.java
+++ b/runtime/src/main/java/io/quarkus/reactivemessaging/http/runtime/HttpMessage.java
@@ -26,7 +26,8 @@ class HttpMessage<T> implements Message<T> {
         this.payload = payload;
         this.successHandler = successHandler;
         this.failureHandler = failureHandler;
-        metadata = Metadata.of(requestMetadata);
+        this.metadata = HttpCloudEventHelper.getBinaryCloudEvent(requestMetadata).map(m -> Metadata.of(requestMetadata, m))
+                .orElse(Metadata.of(requestMetadata));
     }
 
     @Override


### PR DESCRIPTION
CloudEventMetadata is created when http request contains either ce- or ce_ prefixed headers

If outgoing message contains OutgoingCloudEvent Metadata, CE attributes are written in the http response headers