### PR TITLE
Fix http and cloudevent headers concurrently

### DIFF
--- a/runtime/src/main/java/io/quarkus/reactivemessaging/http/runtime/HttpSink.java
+++ b/runtime/src/main/java/io/quarkus/reactivemessaging/http/runtime/HttpSink.java
@@ -151,7 +151,7 @@ class HttpSink {
             // httpHeaders might be inmutable
             Map<String, List<String>> mergedMap = new HashMap<>(httpHeaders);
             for (Entry<String, String> entry : cloudEventHeaders.entrySet()) {
-                httpHeaders.put(entry.getKey(), List.of(entry.getValue()));
+                mergedMap.put(entry.getKey(), List.of(entry.getValue()));
             }
             return mergedMap;
         }


### PR DESCRIPTION
When both http outgoing headers and cloud event meta data are defined only the HTTP headers are sent to the outgoing channel destination.

Signed-off-by: Joshua Mathianas <mathianasj@gmail.com>