### PR TITLE
Bump quarkiverse-parent from 12 to 13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkiverse</groupId>
         <artifactId>quarkiverse-parent</artifactId>
-        <version>12</version>
+        <version>13</version>
     </parent>
     <groupId>io.quarkiverse.reactivemessaging.http</groupId>
     <artifactId>quarkus-reactive-messaging-http-parent</artifactId>


### PR DESCRIPTION
Cherry-pick of https://github.com/quarkiverse/quarkus-reactive-messaging-http/pull/150

Bumps [quarkiverse-parent](https://github.com/quarkiverse/quarkiverse-parent) from 12 to 13.
- [Release notes](https://github.com/quarkiverse/quarkiverse-parent/releases)
- [Commits](https://github.com/quarkiverse/quarkiverse-parent/commits)

---
updated-dependencies:
- dependency-name: io.quarkiverse:quarkiverse-parent dependency-type: direct:production update-type: version-update:semver-major ...

Signed-off-by: dependabot[bot] <support@github.com>
(cherry picked from commit 8d78d8ad145ed55595a60f292b50d45d34caabf5)