### PR TITLE
[quarkus2] Bump quarkiverse-parent from 13 to 15 (#160)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkiverse</groupId>
         <artifactId>quarkiverse-parent</artifactId>
-        <version>13</version>
+        <version>15</version>
     </parent>
     <groupId>io.quarkiverse.reactivemessaging.http</groupId>
     <artifactId>quarkus-reactive-messaging-http-parent</artifactId>


### PR DESCRIPTION
Cherry-pick of https://github.com/quarkiverse/quarkus-reactive-messaging-http/pull/160

Bumps [quarkiverse-parent](https://github.com/quarkiverse/quarkiverse-parent) from 13 to 15.
- [Release notes](https://github.com/quarkiverse/quarkiverse-parent/releases)
- [Commits](https://github.com/quarkiverse/quarkiverse-parent/commits)

---
updated-dependencies:
- dependency-name: io.quarkiverse:quarkiverse-parent dependency-type: direct:production update-type: version-update:semver-major ...

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

(cherry picked from commit 07bab44d840464aa9eb50b77533538b7152a9beb)