### PR TITLE
Fix all asciidoc warnings by using pass macro

### DIFF
--- a/docs/modules/ROOT/pages/reactive-messaging-websocket.adoc
+++ b/docs/modules/ROOT/pages/reactive-messaging-websocket.adoc
@@ -152,7 +152,7 @@ In the next step, we will create configurations for both streams in the `applica
 We need to configure the Web Socket connector. This is done in the `application.properties` file.
 The keys are structured as follows:
 
-`mp.messaging.[outgoing|incoming].{channel-name}.{property}=value`
+`mp.messaging.[outgoing|incoming].pass:[{channel-name}].pass:[{property}]=value`
 
 The `channel-name` segment must match the value set in the `@Incoming` and `@Outgoing` annotation:
 


### PR DESCRIPTION
Asciidoc interprets strings like ${channel-name} as attributes and then issues a WARN during the build that it will skip reference to a missing attribute. This PR uses inline pass macro to tell asciidoc that enclosed content should be excluded from all substitutions.

Proof of all warnings gone:
<img width="691" alt="image" src="https://github.com/quarkiverse/quarkus-reactive-messaging-http/assets/11942401/775506ea-3d16-4f7e-83c7-108720bd1e8f">

Proof of warnings before this PR:
<img width="958" alt="image" src="https://github.com/quarkiverse/quarkus-reactive-messaging-http/assets/11942401/82f013b1-4515-413c-93f2-7b1df7fb9778">
