### PR TITLE
fix all asciidoc warnings by using pass macro (#163)

### DIFF
--- a/docs/modules/ROOT/pages/reactive-messaging-websocket.adoc
+++ b/docs/modules/ROOT/pages/reactive-messaging-websocket.adoc
@@ -152,7 +152,7 @@ In the next step, we will create configurations for both streams in the `applica
 We need to configure the Web Socket connector. This is done in the `application.properties` file.
 The keys are structured as follows:
 
-`mp.messaging.[outgoing|incoming].{channel-name}.{property}=value`
+`mp.messaging.[outgoing|incoming].pass:[{channel-name}].pass:[{property}]=value`
 
 The `channel-name` segment must match the value set in the `@Incoming` and `@Outgoing` annotation:
 


### PR DESCRIPTION
Asciidoc interprets strings like ${channel-name} as attributes and then issues a WARN during the build that it will skip reference to a missing attribute. This commit uses inline pass macro to tell asciidoc that enclosed content should be excluded from all substitutions.

(cherry picked from commit 8051dd7ff30d68c40a6d8d02f7c93d395c142491)