### PR TITLE
Bump ad-m/github-push-action from 0.6.0 to 0.8.0 (#203)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,13 +69,13 @@ jobs:
           git checkout ${{github.base_ref}}
 
       - name: Push changes to ${{github.base_ref}}
-        uses: ad-m/github-push-action@v0.6.0
+        uses: ad-m/github-push-action@v0.8.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{github.base_ref}}
 
       - name: Push tags
-        uses: ad-m/github-push-action@v0.6.0
+        uses: ad-m/github-push-action@v0.8.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           tags: true


### PR DESCRIPTION
Backport of https://github.com/quarkiverse/quarkus-reactive-messaging-http/pull/203

Bumps [ad-m/github-push-action](https://github.com/ad-m/github-push-action) from 0.6.0 to 0.8.0.
- [Release notes](https://github.com/ad-m/github-push-action/releases)
- [Commits](https://github.com/ad-m/github-push-action/compare/v0.6.0...v0.8.0)

---
updated-dependencies:
- dependency-name: ad-m/github-push-action dependency-type: direct:production update-type: version-update:semver-minor ...

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
(cherry picked from commit e37303197d3ecf927cedf2ac6a75084b7e113dfd)