### PR TITLE
added integration with quarkus TLS registry

### DIFF
--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -18,6 +18,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-tls-registry</artifactId>
+        </dependency>        
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jackson-deployment</artifactId>
         </dependency>
         <dependency>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -19,6 +19,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-tls-registry</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jackson</artifactId>
         </dependency>
         <dependency>

--- a/runtime/src/main/java/io/quarkus/reactivemessaging/http/runtime/HttpSink.java
+++ b/runtime/src/main/java/io/quarkus/reactivemessaging/http/runtime/HttpSink.java
@@ -15,8 +15,10 @@ import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
 import org.eclipse.microprofile.reactive.streams.operators.SubscriberBuilder;
 import org.jboss.logging.Logger;
 
+import io.quarkus.reactivemessaging.http.runtime.config.TlsConfig;
 import io.quarkus.reactivemessaging.http.runtime.serializers.Serializer;
 import io.quarkus.reactivemessaging.http.runtime.serializers.SerializerFactoryBase;
+import io.quarkus.tls.TlsConfiguration;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.groups.UniRetry;
 import io.vertx.core.Vertx;
@@ -47,7 +49,8 @@ class HttpSink {
             Optional<Duration> delay,
             Optional<Integer> maxPoolSize,
             Optional<Integer> maxWaitQueueSize,
-            SerializerFactoryBase serializerFactory) {
+            SerializerFactoryBase serializerFactory,
+            TlsConfiguration tlsConfiguration) {
         this.method = method;
         this.url = url;
         this.serializerFactory = serializerFactory;
@@ -60,6 +63,9 @@ class HttpSink {
         if (maxWaitQueueSize.isPresent()) {
             options.setMaxWaitQueueSize(maxWaitQueueSize.get());
         }
+
+        TlsConfig.configure(options, tlsConfiguration);
+
         client = WebClient.create(io.vertx.mutiny.core.Vertx.newInstance(vertx), options);
 
         if (Arrays.stream(SUPPORTED_SCHEMES).noneMatch(url.toLowerCase()::startsWith)) {

--- a/runtime/src/main/java/io/quarkus/reactivemessaging/http/runtime/config/TlsConfig.java
+++ b/runtime/src/main/java/io/quarkus/reactivemessaging/http/runtime/config/TlsConfig.java
@@ -1,0 +1,62 @@
+package io.quarkus.reactivemessaging.http.runtime.config;
+
+import java.util.Optional;
+
+import io.quarkus.tls.TlsConfiguration;
+import io.quarkus.tls.TlsConfigurationRegistry;
+import io.vertx.core.http.HttpClientOptions;
+import io.vertx.core.net.SSLOptions;
+
+public class TlsConfig {
+
+    public static TlsConfiguration lookupConfig(Optional<String> tlsConfigurationName, TlsConfigurationRegistry tlsRegistry,
+            String name) {
+        TlsConfiguration tlsConfiguration = null;
+
+        // Check if we have a named TLS configuration or a default configuration:
+        if (tlsConfigurationName.isPresent()) {
+            Optional<TlsConfiguration> maybeConfiguration = tlsRegistry.get(tlsConfigurationName.get());
+            if (!maybeConfiguration.isPresent()) {
+                throw new IllegalStateException("Unable to find the TLS configuration "
+                        + tlsConfigurationName.get() + " for the websocket sink " + name + ".");
+            }
+            tlsConfiguration = maybeConfiguration.get();
+        } else if (tlsRegistry.getDefault().isPresent()) {
+            tlsConfiguration = tlsRegistry.getDefault().get();
+        }
+        return tlsConfiguration;
+    }
+
+    public static void configure(HttpClientOptions options, TlsConfiguration tlsConfiguration) {
+        if (tlsConfiguration != null) {
+            options.setSsl(true);
+
+            if (tlsConfiguration.getTrustStoreOptions() != null) {
+                options.setTrustOptions(tlsConfiguration.getTrustStoreOptions());
+            }
+
+            // For mTLS:
+            if (tlsConfiguration.getKeyStoreOptions() != null) {
+                options.setKeyCertOptions(tlsConfiguration.getKeyStoreOptions());
+            }
+
+            if (tlsConfiguration.isTrustAll()) {
+                options.setTrustAll(true);
+            }
+
+            SSLOptions sslOptions = tlsConfiguration.getSSLOptions();
+            if (sslOptions != null) {
+                options.setSslHandshakeTimeout(sslOptions.getSslHandshakeTimeout());
+                options.setSslHandshakeTimeoutUnit(sslOptions.getSslHandshakeTimeoutUnit());
+                for (String suite : sslOptions.getEnabledCipherSuites()) {
+                    options.addEnabledCipherSuite(suite);
+                }
+                for (io.vertx.core.buffer.Buffer buffer : sslOptions.getCrlValues()) {
+                    options.addCrlValue(buffer);
+                }
+                options.setEnabledSecureTransportProtocols(sslOptions.getEnabledSecureTransportProtocols());
+
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR brings in integration with Quarkus TLS registry to allow easily register custom certificates etc that should be used by the HttpSink/WebScoektSink part.