### PR TITLE
Prepare for Release 2.5.0

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,3 +1,3 @@
 release:
-  current-version: 2.4.1
+  current-version: 2.5.0
   next-version: 999-SNAPSHOT


### PR DESCRIPTION
It's been a long time since we released a new version. This one should bring compatibility to the latest Quarkus versions to this date.