### PR TITLE
[main-lts] - Add support to Quarkus 3.20 LTS and Jandex 3.2.7

### DIFF
--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,4 +1,4 @@
-:quarkus-version: 3.21.3
+:quarkus-version: 3.20.0
 :project-version: 2.5.0
 :maven-version: 3.8.1+
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,9 @@
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus.version>3.21.3</quarkus.version>
+    <!-- Must be aligned with Quarkus -->
+    <jandex-plugin.version>3.2.7</jandex-plugin.version>
+    <quarkus.version>3.20.0</quarkus.version>
     <assertj.version>3.27.3</assertj.version>
     <mutiny-zero.version>1.1.1</mutiny-zero.version>
   </properties>
@@ -78,6 +80,7 @@
         <plugin>
           <groupId>io.smallrye</groupId>
           <artifactId>jandex-maven-plugin</artifactId>
+          <version>${jandex-plugin.version}</version>
           <executions>
             <execution>
               <id>make-index</id>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,6 @@
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <jandex-plugin.version>3.3.0</jandex-plugin.version>
     <quarkus.version>3.21.3</quarkus.version>
     <assertj.version>3.27.3</assertj.version>
     <mutiny-zero.version>1.1.1</mutiny-zero.version>
@@ -79,7 +78,6 @@
         <plugin>
           <groupId>io.smallrye</groupId>
           <artifactId>jandex-maven-plugin</artifactId>
-          <version>${jandex-plugin.version}</version>
           <executions>
             <execution>
               <id>make-index</id>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -10,7 +11,8 @@
 
     <artifactId>quarkus-reactive-messaging-http</artifactId>
     <name>Quarkus - SmallRye Reactive Messaging - HTTP and WebSockets - Runtime</name>
-    <description>Connect to HTTP or WebSocket and expose HTTP or WebSocket endpoints for Reactive Messaging</description>
+    <description>Connect to HTTP or WebSocket and expose HTTP or WebSocket endpoints for Reactive Messaging
+    </description>
 
     <dependencies>
         <dependency>
@@ -65,7 +67,8 @@
                             <goal>extension-descriptor</goal>
                         </goals>
                         <configuration>
-                            <deployment>${project.groupId}:${project.artifactId}-deployment:${project.version}</deployment>
+                            <deployment>${project.groupId}:${project.artifactId}-deployment:${project.version}
+                            </deployment>
                         </configuration>
                     </execution>
                 </executions>
@@ -98,16 +101,17 @@
                 </executions>
             </plugin>
             <plugin>
-              <groupId>io.smallrye</groupId>
-              <artifactId>jandex-maven-plugin</artifactId>
-              <executions>
-                <execution>
-                  <id>make-index</id>
-                  <goals>
-                    <goal>jandex</goal>
-                  </goals>
-                </execution>
-              </executions>
+                <groupId>io.smallrye</groupId>
+                <artifactId>jandex-maven-plugin</artifactId>
+                <version>${jandex-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>make-index</id>
+                        <goals>
+                            <goal>jandex</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
We should also support Quarkus LTS.