### PR TITLE
Add snapshot deploy workflow and bump Quarkus docs version to 3.39.1

### DIFF
--- a/.github/workflows/snapshots_deploy.yml
+++ b/.github/workflows/snapshots_deploy.yml
@@ -1,0 +1,28 @@
+name: Snapshot Deploy
+
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  attestations: write
+  id-token: write
+  contents: read
+
+jobs:
+  deploy-snapshot:
+    name: Deploy Snapshots
+    uses: quarkiverse/.github/.github/workflows/perform-release.yml@main
+    secrets: inherit
+    with:
+      ref: main
+      version: 999-SNAPSHOT

--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,4 +1,4 @@
-:quarkus-version: 3.36.0
+:quarkus-version: 3.39.1
 :project-version: 2.8.0
 :maven-version: 3.8.1+
 


### PR DESCRIPTION
Add a new GitHub Actions workflow that publishes snapshot artifacts to the repository on every push to main and on manual dispatch. Also update the Quarkus version referenced in the AsciiDoc attributes file from 3.36.0 to 3.39.1.